### PR TITLE
Change URL for Webring neighbour TomasMaillo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
     </nav>
 
     <footer>
-        <a class="neighbour-link start" href="https://tomasmaillo.com">tomasmaillo.com</a>
+        <a class="neighbour-link start" href="https://experiments.tomasmaillo.com/">TomasMaillo</a>
         <div id="central-links">
             <a class="footer-link" id='linkedin'
                 href="https://www.linkedin.com/in/pierre-lardet-351ba425b/">LinkedIn</a>


### PR DESCRIPTION
Right now I am using [experiments.tomasmaillo.com](https://experiments.tomasmaillo.com/) for our webring and not [tomasmaillo.com](https://tomasmaillo.com/) 
But please feel free to change the displayed text to whatever you like :D